### PR TITLE
🐜 feat(ci): Create reusable CI job to validate devcontainer setups

### DIFF
--- a/validate-devcontainer/action.yml
+++ b/validate-devcontainer/action.yml
@@ -1,0 +1,16 @@
+name: "Validate devcontainer"
+description: "Validates that this repository has a working devcontainer configuration"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+
+    - name: Validate devcontainer
+      # This action will install the devcontainers CLI, build the container,
+      # start it, and run the postCreateCommand.
+      uses: devcontainers/ci@8bf61b26e9c3a98f69cb6ce2f88d24ff59b785c6 # v0.3
+      with:
+        # TODO(VAST-484): Maybe this isn't even necessary, try it out.
+        workspace-folder: ${{ github.workspace }}

--- a/validate-devcontainer/action.yml
+++ b/validate-devcontainer/action.yml
@@ -7,6 +7,11 @@ inputs:
     required: false
     default: "true" # The POSIX shell no-op, not the boolean ;)
 
+outputs:
+  runCmdOutput:
+    description: "Output from the runCmd command"
+    value: ${{ steps.validate.outputs.runCmdOutput }}
+
 runs:
   using: "composite"
   steps:
@@ -14,8 +19,10 @@ runs:
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
     - name: Validate devcontainer
+      id: validate
       # This action will install the devcontainers CLI, build the container,
-      # start it, and run the postCreateCommand.
+      # start it (running the devcontainer's postCreateCommand etc.),
+      # then the runCmd.
       uses: devcontainers/ci@8bf61b26e9c3a98f69cb6ce2f88d24ff59b785c6 # v0.3
       with:
         runCmd: ${{ inputs.runCmd }}

--- a/validate-devcontainer/action.yml
+++ b/validate-devcontainer/action.yml
@@ -1,6 +1,12 @@
 name: "Validate devcontainer"
 description: "Validates that this repository has a working devcontainer configuration"
 
+inputs:
+  runCmd:
+    description: "Command to run inside the devcontainer to validate it works"
+    required: false
+    default: "true" # The POSIX shell no-op, not the boolean ;)
+
 runs:
   using: "composite"
   steps:
@@ -12,5 +18,4 @@ runs:
       # start it, and run the postCreateCommand.
       uses: devcontainers/ci@8bf61b26e9c3a98f69cb6ce2f88d24ff59b785c6 # v0.3
       with:
-        # TODO(VAST-484): Maybe this isn't even necessary, try it out.
-        workspace-folder: ${{ github.workspace }}
+        runCmd: ${{ inputs.runCmd }}


### PR DESCRIPTION
# VAST-484 Create reusable CI job to validate devcontainer setups

## Context

Several of our repositories have a devcontainer setup for development.
This is usually not tested in CI, only when a developer checks out the repository sets it up locally or in Codespaces, so breakages sometimes go unnoticed.

## Contents

This PR adds a reusable GitHub Actions composite action that other repositories can use to test their devcontainer setup.

It doesn't do a lot right now except confirm the container builds and starts, but might evolve as our devcontainer use becomes more standardized.

## Notes
* Linting didn't make sense to set up for this little YAML (and `actionlint` doesn't run on composite actions).
* See some example runs at https://github.com/swisstxt-ast/gh-action-debugging/pull/2